### PR TITLE
Forgot 3 values in FlightData2 for FalconBMS 4.38

### DIFF
--- a/falcon_memreader.py
+++ b/falcon_memreader.py
@@ -177,6 +177,9 @@ class FlightData2(ctypes.Structure):
         ("iffTransponderActiveCode3A", ctypes.c_short),
         ("iffTransponderActiveCodeC", ctypes.c_short),
         ("iffTransponderActiveCode4", ctypes.c_short),
+        ("tacan_ils_frequency", ctypes.c_int),
+        ("desired_RTT_FPS", ctypes.c_int),
+        ("sideSlipdeg", ctypes.c_float),
         ]
 
 class OsbLabel(ctypes.Structure):


### PR DESCRIPTION
I forgot 3 values tacan_ils_frequency, desired_RTT_FPS and slideSlipdeg for FalconBMS 4.38